### PR TITLE
🎉 Release 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@
 
 ### Misc
 
+- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
+- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
 - fix badge in readme ([ae167f5](https://github.com/CrystalNET-org/helm-romm/commit/ae167f5beb88250d4edb9f299a63804cb2b2b3cc))
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.16](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.16) - 2023-12-23
+
+### ❤️ Thanks to all contributors! ❤️
+
+@Psych0D0g
+
+### Misc
+
+- fix badge in readme ([ae167f5](https://github.com/CrystalNET-org/helm-romm/commit/ae167f5beb88250d4edb9f299a63804cb2b2b3cc))
+
 ## [0.2.15](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.15) - 2023-12-23
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,15 @@
 # Changelog
 
-## [0.2.16](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.16) - 2023-12-23
+## [0.2.16](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.16) - 2024-01-02
 
 ### ❤️ Thanks to all contributors! ❤️
 
-@Psych0D0g
+@psych0d0g, @Psych0D0g
 
 ### Misc
 
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
 - fix badge in readme ([ae167f5](https://github.com/CrystalNET-org/helm-romm/commit/ae167f5beb88250d4edb9f299a63804cb2b2b3cc))
 
 ## [0.2.15](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.15) - 2023-12-23

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>

--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
   ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
-  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/psych0d0g)](https://artifacthub.io/packages/helm/psych0d0g/romm)
+  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: romm
 type: application
 home: https://zurdi15.github.io/romm/
 icon: https://raw.githubusercontent.com/psych0d0g/helm-charts/main/charts/romm/icon.png
-version: 0.2.15
+version: 0.2.16
 # renovate: image=zurdi15/romm
 appVersion: "2.1.0"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
-  ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
+  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,9 +18,9 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.15](https://img.shields.io/badge/Version-0.2.15-informational?style=flat-square)
+  ![Version: 0.2.16](https://img.shields.io/badge/Version-0.2.16-informational?style=flat-square)
   ![AppVersion: 2.1.0](https://img.shields.io/badge/AppVersion-2.1.0-informational?style=flat-square)
-  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/psych0d0g)](https://artifacthub.io/packages/helm/psych0d0g/romm)
+  [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.16` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.16](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.16) - 2024-01-02

### Misc

- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
- fix badge in readme ([ae167f5](https://github.com/CrystalNET-org/helm-romm/commit/ae167f5beb88250d4edb9f299a63804cb2b2b3cc))