### PR TITLE
🎉 Release 0.2.16

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,10 @@
 
 ### Misc
 
+- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
+- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
 - Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
+- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
 - Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.16` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.16](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.16) - 2024-01-02

### Misc

- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
- 🎉 Release 0.2.16 [[#7](https://github.com/CrystalNET-org/helm-romm/pull/7)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
- Update zurdi15/romm Docker tag to v2.2.1 [[#9](https://github.com/CrystalNET-org/helm-romm/pull/9)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.115.0 [[#8](https://github.com/CrystalNET-org/helm-romm/pull/8)]
- fix badge in readme ([ae167f5](https://github.com/CrystalNET-org/helm-romm/commit/ae167f5beb88250d4edb9f299a63804cb2b2b3cc))