### PR TITLE
🎉 Release 0.2.20

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 
 ### Misc
 
+- Update Helm release mariadb to ~15.2.0 [[#21](https://github.com/CrystalNET-org/helm-romm/pull/21)]
 - Update Helm release redis to ~18.7.0 [[#18](https://github.com/CrystalNET-org/helm-romm/pull/18)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#16](https://github.com/CrystalNET-org/helm-romm/pull/16)]
 - Update zurdi15/romm Docker tag to v2.3.1 [[#17](https://github.com/CrystalNET-org/helm-romm/pull/17)]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+## [0.2.20](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.20) - 2024-01-05
+
+### ❤️ Thanks to all contributors! ❤️
+
+@psych0d0g
+
+### Misc
+
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#14](https://github.com/CrystalNET-org/helm-romm/pull/14)]
+
 ## [0.2.19](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.19) - 2024-01-02
 
 ### ❤️ Thanks to all contributors! ❤️

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## [0.2.20](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.20) - 2024-01-05
+## [0.2.20](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.20) - 2024-01-20
 
 ### ❤️ Thanks to all contributors! ❤️
 
@@ -8,6 +8,9 @@
 
 ### Misc
 
+- Update Helm release redis to ~18.7.0 [[#18](https://github.com/CrystalNET-org/helm-romm/pull/18)]
+- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#16](https://github.com/CrystalNET-org/helm-romm/pull/16)]
+- Update zurdi15/romm Docker tag to v2.3.1 [[#17](https://github.com/CrystalNET-org/helm-romm/pull/17)]
 - Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#14](https://github.com/CrystalNET-org/helm-romm/pull/14)]
 
 ## [0.2.19](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.19) - 2024-01-02

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
 | https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart

--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square)
+  ![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square)
   ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square)
-  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>
@@ -86,7 +86,7 @@ Kubernetes: `>=1.22.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.6.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart
 

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: romm
 type: application
 home: https://zurdi15.github.io/romm/
 icon: https://raw.githubusercontent.com/CrystalNET-org/helm-romm/main/chart/icon.png
-version: 0.2.19
+version: 0.2.20
 # renovate: image=zurdi15/romm
 appVersion: "2.2.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/Chart.yaml
+++ b/chart/Chart.yaml
@@ -5,7 +5,7 @@ name: romm
 type: application
 home: https://zurdi15.github.io/romm/
 icon: https://raw.githubusercontent.com/CrystalNET-org/helm-romm/main/chart/icon.png
-version: 0.2.21
+version: 0.2.20
 # renovate: image=zurdi15/romm
 appVersion: "2.3.1"
 kubeVersion: ">=1.22.0-0"

--- a/chart/README.md
+++ b/chart/README.md
@@ -85,7 +85,7 @@ Kubernetes: `>=1.22.0-0`
 
 | Repository | Name | Version |
 |------------|------|---------|
-| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
+| https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.2.0 |
 | https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart

--- a/chart/README.md
+++ b/chart/README.md
@@ -18,7 +18,7 @@
   ](LICENSE)
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
-  ![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square)
+  ![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square)
   ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 

--- a/chart/README.md
+++ b/chart/README.md
@@ -19,7 +19,7 @@
   <br/>
   ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
   ![Version: 0.2.20](https://img.shields.io/badge/Version-0.2.20-informational?style=flat-square)
-  ![AppVersion: 2.2.1](https://img.shields.io/badge/AppVersion-2.2.1-informational?style=flat-square)
+  ![AppVersion: 2.3.1](https://img.shields.io/badge/AppVersion-2.3.1-informational?style=flat-square)
   [![Artifact Hub](https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/CrystalNET)](https://artifacthub.io/packages/helm/crystalnet/romm)
 
 </div>
@@ -86,7 +86,7 @@ Kubernetes: `>=1.22.0-0`
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | mariadb(mariadb) | ~15.0.0 |
-| https://charts.bitnami.com/bitnami | redis(redis) | ~18.6.0 |
+| https://charts.bitnami.com/bitnami | redis(redis) | ~18.7.0 |
 
 ## Installing the Chart
 


### PR DESCRIPTION
This PR was opened by the [ready-release-go](https://github.com/woodpecker-ci/plugin-ready-release-go) plugin. When you're ready to do a release, you can merge this pull-request and a new release with version `0.2.20` will be created automatically. If you're not ready to do a release yet, that's fine, whenever you add more changes to `main` this pull-request will be updated.

## Options

- [ ] Mark this version as a release candidate

## [0.2.20](https://github.com/CrystalNET-org/helm-romm/releases/tag/0.2.20) - 2024-01-20

### Misc

- Update Helm release mariadb to ~15.2.0 [[#21](https://github.com/CrystalNET-org/helm-romm/pull/21)]
- Update Helm release redis to ~18.7.0 [[#18](https://github.com/CrystalNET-org/helm-romm/pull/18)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.140.10 [[#16](https://github.com/CrystalNET-org/helm-romm/pull/16)]
- Update zurdi15/romm Docker tag to v2.3.1 [[#17](https://github.com/CrystalNET-org/helm-romm/pull/17)]
- Update harbor.crystalnet.org/dockerhub-proxy/renovate/renovate Docker tag to v37.122.0 [[#14](https://github.com/CrystalNET-org/helm-romm/pull/14)]